### PR TITLE
improving the tables and cards

### DIFF
--- a/src/reports/rpt_stream_names/templates/report.css
+++ b/src/reports/rpt_stream_names/templates/report.css
@@ -1,1 +1,22 @@
-/* ONLY STYLES FOR RIVERS NEED SPACE REPORT */
+/* Stream Names report-specific styles */
+
+/**
+TABLE FORMATTING
+*/
+table,
+table.dataframe {
+	/* Collapse prevents visible corner radius in many table setups (including Pico defaults). */
+	border-collapse: separate;
+	border-spacing: 0;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #fff;
+}
+
+
+/* Light blue separators between header cells. */
+table thead th + th,
+table.dataframe thead th + th {
+	border-left: 1px solid #c7dbf344;
+}
+

--- a/src/util/html/templates/highlight_cards.css
+++ b/src/util/html/templates/highlight_cards.css
@@ -1,0 +1,189 @@
+/*
+Highlight cards shared styles.
+Load this stylesheet only in reports that render render_highlight_cards.
+*/
+
+#highlight-cards {
+	margin: 1.5rem 0 2.25rem;
+}
+
+#highlight-cards .highlight-card-grid {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+	gap: 1rem 1.25rem;
+}
+
+#highlight-cards .highlight-card {
+	--card-accent: #1f5ca5;
+	--icon-grad-start: #2b72bd;
+	--icon-grad-end: #0e4f99;
+
+	display: grid;
+	grid-template-columns: 7.25rem minmax(0, 1fr);
+	grid-template-rows: auto auto;
+	column-gap: 0.95rem;
+	row-gap: 0.6rem;
+	align-items: start;
+
+	background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+	border: 1px solid #d5deeb;
+	border-top: 4px solid var(--card-accent);
+	border-radius: 14px;
+	box-shadow: 0 3px 12px rgba(0, 26, 58, 0.14);
+	padding: 1.1rem 1.35rem 1rem;
+	list-style: none;
+}
+
+#highlight-cards .highlight-card[data-theme="blue"] {
+	--card-accent: #1f5ca5;
+	--icon-grad-start: #2b72bd;
+	--icon-grad-end: #0e4f99;
+}
+
+#highlight-cards .highlight-card[data-theme="green"] {
+	--card-accent: #3d8f3b;
+	--icon-grad-start: #63b348;
+	--icon-grad-end: #3c8f34;
+}
+
+#highlight-cards .highlight-card[data-theme="teal"] {
+	--card-accent: #1f7f80;
+	--icon-grad-start: #28a3a5;
+	--icon-grad-end: #1b7f80;
+}
+
+#highlight-cards .highlight-card__header {
+	grid-column: 2;
+	min-width: 0;
+}
+
+#highlight-cards .highlight-card__icon {
+	grid-column: 1;
+	grid-row: 1;
+	display: flex;
+	justify-content: center;
+	padding-top: 0.05rem;
+}
+
+#highlight-cards .highlight-card__icon .material-icons {
+	width: 78px;
+	height: 78px;
+	border-radius: 50%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: #fff;
+	font-size: 2.35rem;
+	line-height: 1;
+	background: radial-gradient(circle at 30% 24%, var(--icon-grad-start), var(--icon-grad-end));
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22), 0 2px 6px rgba(0, 0, 0, 0.16);
+}
+
+#highlight-cards .highlight-card__label {
+	display: block;
+	color: var(--card-accent);
+	text-transform: uppercase;
+	letter-spacing: 0.045em;
+	font-size: 0.72rem;
+	font-weight: 700;
+	line-height: 1.2;
+}
+
+#highlight-cards .highlight-card__primary {
+	color: var(--card-accent);
+	font-family: var(--body-font-family);
+	font-size: clamp(2.15rem, 3.15vw, 3.65rem);
+	font-weight: 700;
+	letter-spacing: 0.004em;
+	line-height: 1.03;
+	margin: 0.08rem 0 0.3rem;
+	overflow-wrap: anywhere;
+}
+
+#highlight-cards .highlight-card__secondary {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	color: #3d4655;
+	font-size: 0.77rem;
+	line-height: 1.25;
+	margin-bottom: 0;
+}
+
+#highlight-cards .highlight-card__secondary .material-icons {
+	color: var(--card-accent);
+	font-size: 1.08rem;
+	line-height: 1;
+}
+
+#highlight-cards .highlight-card__footer {
+	grid-column: 1 / -1;
+	border-top: 2px solid #dbe3ee;
+	padding-top: 0.62rem;
+	padding-left: 0.05rem;
+	display: flex;
+	align-items: baseline;
+	gap: 0.65rem;
+	justify-content: center;
+}
+
+#highlight-cards .highlight-card__footer-metric {
+	color: var(--card-accent);
+	font-size: 2.12rem;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	line-height: 1;
+}
+
+#highlight-cards .highlight-card__footer-label {
+	color: #4d5666;
+	font-size: 0.99rem;
+	line-height: 1.2;
+	font-weight: 500;
+}
+
+@media (max-width: 760px) {
+	#highlight-cards .highlight-card-grid {
+		grid-template-columns: 1fr;
+	}
+
+	#highlight-cards .highlight-card {
+		grid-template-columns: 4.35rem minmax(0, 1fr);
+		padding: 0.95rem 1rem;
+		column-gap: 0.72rem;
+	}
+
+	#highlight-cards .highlight-card__header {
+		grid-column: 2;
+	}
+
+	#highlight-cards .highlight-card__icon {
+		justify-content: flex-start;
+	}
+
+	#highlight-cards .highlight-card__icon .material-icons {
+		width: 58px;
+		height: 58px;
+		font-size: 1.8rem;
+	}
+
+	#highlight-cards .highlight-card__primary {
+		font-size: clamp(1.8rem, 9vw, 2.45rem);
+	}
+
+	#highlight-cards .highlight-card__secondary {
+		font-size: 0.83rem;
+	}
+
+	#highlight-cards .highlight-card__footer-metric {
+		font-size: 1.8rem;
+		text-align: left;
+	}
+
+	#highlight-cards .highlight-card__footer-label {
+		font-size: 0.95rem;
+	}
+}

--- a/src/util/html/templates/macros.html
+++ b/src/util/html/templates/macros.html
@@ -42,17 +42,25 @@ Example Usage:
 {{ render_highlight_cards(highlight_cards) }}
 #}
 {% macro render_highlight_cards(cards) -%}
+<style>
+/* NOTE: You may see an error on the next line but it is a false HTML/CSS Parser error. 
+  Just ignore it
+*/
+{% include 'highlight_cards.css' %}
+</style>
 <ul class="highlight-card-grid">
     {% for card in cards %}
     <li class="highlight-card" data-theme="{{ card.theme }}">
-        <div class="highlight-card__header">
-            <span class="material-icons" aria-hidden="true">{{ card.icon }}</span>
-            <span class="highlight-card__label">{{ card.header }}</span>
+        <div class="highlight-card__icon">
+          <span class="material-icons" aria-hidden="true">{{ card.icon }}</span>
         </div>
-        <div class="highlight-card__primary">{{ card.primary_value }}</div>
-        <div class="highlight-card__secondary">
-            <span class="material-icons" aria-hidden="true">{{ card.secondary_stat.icon }}</span>
-            <span>{{ card.secondary_stat.text }}</span>
+        <div class="highlight-card__header">
+            <span class="highlight-card__label">{{ card.header }}</span>
+            <div class="highlight-card__primary">{{ card.primary_value }}</div>
+            <div class="highlight-card__secondary">
+                <span class="material-icons" aria-hidden="true">{{ card.secondary_stat.icon }}</span>
+                <span>{{ card.secondary_stat.text }}</span>
+            </div>
         </div>
         <div class="highlight-card__footer">
             <span class="highlight-card__footer-metric">{{ card.footer.metric }}</span>


### PR DESCRIPTION
THis is just a rough first-pass at the styling for the cards.

For now this has been only added to the specific stream name report although since the macro is in `util` there is an argument for putting it there instead. 

- Highlight card styling exists next to `macros.html` since those should probably always be together.
- Table styling is inside the report itself. Not sure if we wanted that to be applied to all reportsz

<img width="827" height="368" alt="image" src="https://github.com/user-attachments/assets/b0d49bd9-1abe-4ff7-a10f-c59acd18bd16" />
